### PR TITLE
Refactor code for improved readability

### DIFF
--- a/include/odrive_hw_interface/odrive_hw_interface.hpp
+++ b/include/odrive_hw_interface/odrive_hw_interface.hpp
@@ -5,51 +5,59 @@
 #include <string>
 #include <vector>
 
-
+#include <hardware_interface/actuator_interface.hpp>
+#include <hardware_interface/handle.hpp>
 #include <hardware_interface/hardware_info.hpp>
-#include "hardware_interface/actuator_interface.hpp"
-#include "hardware_interface/handle.hpp"
-#include "hardware_interface/hardware_info.hpp"
-#include "hardware_interface/system_interface.hpp"
-#include "hardware_interface/types/hardware_interface_return_values.hpp"
-#include "rclcpp/macros.hpp"
-#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include <hardware_interface/hardware_info.hpp>
+#include <hardware_interface/system_interface.hpp>
+#include <hardware_interface/types/hardware_interface_return_values.hpp>
+#include <hardware_interface/types/hardware_interface_type_values.hpp>
+
+#include <rclcpp/macros.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include "odrive-can.hpp"
 
-using hardware_interface::return_type;
-
-namespace odrive_hw_interface {
+namespace odrive_hw_interface
+{
+    using hardware_interface::return_type;
 
     class OdriveHardware : public hardware_interface::ActuatorInterface
     {
     public:
         RCLCPP_SHARED_PTR_DEFINITIONS(OdriveHardware)
 
-        CallbackReturn on_init(const hardware_interface::HardwareInfo & info) override;
+        OdriveHardware();
+
+        CallbackReturn on_init(const hardware_interface::HardwareInfo &info) override;
 
         std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
-
         std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
 
-        CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
+        CallbackReturn on_activate(const rclcpp_lifecycle::State &previous_state) override;
+        CallbackReturn on_deactivate(const rclcpp_lifecycle::State &previous_state) override;
 
-        CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
+        return_type read(const rclcpp::Time &time, const rclcpp::Duration &period) override;
+        return_type write(const rclcpp::Time &time, const rclcpp::Duration &period) override;
 
-        return_type read(const rclcpp::Time & time, const rclcpp::Duration & period) override;
-
-        return_type write(const rclcpp::Time & time, const rclcpp::Duration & period) override;
-
-     private:
+    private:
         // Store the command for the simulated robot
         double hw_joint_command_;
         double hw_joint_state_;
 
-        OdriveCAN *odrive; 
+        OdriveCAN *odrive;
 
+        template <typename _HwInterface>
+        static inline std::vector<_HwInterface> export_interfaces()
+        {
+            std::vector<_HwInterface> interfaces;
+            auto joint_name = info_.joints[0].name;
+            auto interface = _HwInterface(joint_name, HW_IF_EFFORT, &hw_joint_state_);
+            interfaces.emplace_back(interface);
+            return interfaces;
+        };
     };
 
-}  // namespace odrive_hw_interface
+} // namespace odrive_hw_interface
 
-#endif  // ODRIVE_HW_INTERFACE__ODRIVE_HW_INTERFACE_HPP_
+#endif // ODRIVE_HW_INTERFACE__ODRIVE_HW_INTERFACE_HPP_

--- a/src/odrive_hw_interface.cpp
+++ b/src/odrive_hw_interface.cpp
@@ -10,123 +10,130 @@
 
 namespace odrive_hw_interface
 {
-hardware_interface::CallbackReturn OdriveHardware::on_init(
-  const hardware_interface::HardwareInfo & info)
+#define ODRIVE_LOGGER rclcpp::get_logger("OdriveHardware")
+#define LOG_AND_RETURN_IF_FATAL(condition, ...)       \
+    do                                                \
+    {                                                 \
+        if (condition)                                \
+        {                                             \
+            RCLCPP_FATAL(ODRIVE_LOGGER, __VA_ARGS__); \
+            return CallbackReturn::ERROR;             \
+        }                                             \
+    } while (0)
+
+    using hardware_interface::ActuatorInterface;
+    using hardware_interface::CallbackReturn;
+    using hardware_interface::CommandInterface;
+    using hardware_interface::ComponentInfo;
+    using hardware_interface::HardwareInfo;
+    using hardware_interface::HW_IF_EFFORT;
+    using hardware_interface::InterfaceInfo;
+    using hardware_interface::return_type;
+    using hardware_interface::StateInterface;
+
+OdriveHardware::OdriveHardware()
+    : ActuatorInterface()
 {
-  if (hardware_interface::ActuatorInterface::on_init(info) != CallbackReturn::SUCCESS)
-  {
+    this->hw_joint_state_ = std::numeric_limits<double>::quiet_NaN();
+    this->hw_joint_command_ = std::numeric_limits<double>::quiet_NaN();
+}
+
+CallbackReturn OdriveHardware::on_init(const HardwareInfo &info)
+{
+    if (ActuatorInterface::on_init(info) != CallbackReturn::SUCCESS)
+    {
+        return CallbackReturn::SUCCESS;
+    }
+    RCLCPP_INFO(ODRIVE_LOGGER, "Interface init");
+
+    const ComponentInfo &joint = info_.joints[0];
+    const char *jname = joint.name.c_str();
+    LOG_AND_RETURN_IF_FATAL(
+        joint.command_interfaces.size() != 1,
+        "Joint '%s' has %zu command interfaces found. 1 expected.",
+        jname, joint.command_interfaces.size());
+
+    auto interface = &joint.command_interfaces[0];
+    LOG_AND_RETURN_IF_FATAL(
+        interface->name != HW_IF_EFFORT,
+        "Joint '%s' have %s command interfaces found. '%s' expected.",
+        jname, interface->name.c_str(), HW_IF_EFFORT);
+
+    LOG_AND_RETURN_IF_FATAL(
+        joint.state_interfaces.size() != 1,
+        "Joint '%s' has %zu state interface. 1 expected.", jname);
+
+    interface = &joint.state_interfaces[0];
+    LOG_AND_RETURN_IF_FATAL(
+        interface->name != HW_IF_EFFORT,
+        "Joint '%s' have %s state interface. '%s' expected.",
+        jname, interface->name.c_str(), HW_IF_EFFORT);
+
+    int id = 0;
+    char can_if[] = "can0";
+    this->odrive = new OdriveCAN(id, can_if);
+
     return CallbackReturn::SUCCESS;
-  }
-   RCLCPP_INFO(
-      rclcpp::get_logger("OdriveHardware"), "Interface init");
-
-  hw_joint_state_ = std::numeric_limits<double>::quiet_NaN();
-  hw_joint_command_ = std::numeric_limits<double>::quiet_NaN();
-
-  const hardware_interface::ComponentInfo & joint = info_.joints[0];
-
-  if (joint.command_interfaces.size() != 1)
-  {
-    RCLCPP_FATAL(
-      rclcpp::get_logger("OdriveHardware"),
-      "Joint '%s' has %zu command interfaces found. 1 expected.", joint.name.c_str(),
-      joint.command_interfaces.size());
-    return hardware_interface::CallbackReturn::ERROR;
-  }
-
-  if (joint.command_interfaces[0].name != hardware_interface::HW_IF_EFFORT)
-  {
-    RCLCPP_FATAL(
-      rclcpp::get_logger("OdriveHardware"),
-      "Joint '%s' have %s command interfaces found. '%s' expected.", joint.name.c_str(),
-      joint.command_interfaces[0].name.c_str(), hardware_interface::HW_IF_EFFORT);
-    return hardware_interface::CallbackReturn::ERROR;
-  }
-
-  if (joint.state_interfaces.size() != 1)
-  {
-    RCLCPP_FATAL(
-      rclcpp::get_logger("OdriveHardware"), "Joint '%s' has %zu state interface. 1 expected.",
-      joint.name.c_str(), joint.state_interfaces.size());
-    return hardware_interface::CallbackReturn::ERROR;
-  }
-
-  if (joint.state_interfaces[0].name != hardware_interface::HW_IF_EFFORT)
-  {
-    RCLCPP_FATAL(
-      rclcpp::get_logger("OdriveHardware"), "Joint '%s' have %s state interface. '%s' expected.",
-      joint.name.c_str(), joint.state_interfaces[0].name.c_str(),
-      hardware_interface::HW_IF_EFFORT);
-    return hardware_interface::CallbackReturn::ERROR;
-  }
-
-  int id = 0;
-  char can_if[] = "can0";
-  this->odrive =  new OdriveCAN(id,can_if);
-  
-
-  return CallbackReturn::SUCCESS;
 }
 
+    std::vector<StateInterface> OdriveHardware::export_state_interfaces()
+    {
+        std::vector<StateInterface> state_interfaces;
+        state_interfaces.emplace_back(StateInterface(
+            this->info_.joints[0].name, HW_IF_EFFORT, &hw_joint_state_));
+        return state_interfaces;
+    }
 
-std::vector<hardware_interface::StateInterface> OdriveHardware::export_state_interfaces()
-{
-  std::vector<hardware_interface::StateInterface> state_interfaces;
-  state_interfaces.emplace_back(hardware_interface::StateInterface(
-    info_.joints[0].name, hardware_interface::HW_IF_EFFORT, &hw_joint_state_));
-  return state_interfaces;
-}
+    std::vector<CommandInterface> OdriveHardware::export_command_interfaces()
+    {
+        std::vector<CommandInterface> command_interfaces;
+        command_interfaces.emplace_back(CommandInterface(
+            this->info_.joints[0].name, HW_IF_EFFORT, &hw_joint_command_));
+        return command_interfaces;
+    }
 
-std::vector<hardware_interface::CommandInterface> OdriveHardware::export_command_interfaces()
-{
-  std::vector<hardware_interface::CommandInterface> command_interfaces;
-  command_interfaces.emplace_back(hardware_interface::CommandInterface(
-    info_.joints[0].name, hardware_interface::HW_IF_EFFORT, &hw_joint_command_));
-  return command_interfaces;
-}
+    CallbackReturn OdriveHardware::on_activate(
+        const rclcpp_lifecycle::State & /*previous_state*/)
+    {
 
-hardware_interface::CallbackReturn OdriveHardware::on_activate(
-  const rclcpp_lifecycle::State & /*previous_state*/)
-{
+        // TODO(anyone): prepare the robot to receive commands
+        this->odrive->motor_on();
 
-  // TODO(anyone): prepare the robot to receive commands
-  this->odrive->motor_on();
+        return CallbackReturn::SUCCESS;
+    }
 
-  return CallbackReturn::SUCCESS;
-}
+    CallbackReturn OdriveHardware::on_deactivate(
+        const rclcpp_lifecycle::State & /*previous_state*/)
+    {
+        // TODO(anyone): prepare the robot to stop receiving commands
+        this->odrive->motor_off();
 
-hardware_interface::CallbackReturn OdriveHardware::on_deactivate(
-  const rclcpp_lifecycle::State & /*previous_state*/)
-{
-  // TODO(anyone): prepare the robot to stop receiving commands
-  this->odrive->motor_off();
+        return CallbackReturn::SUCCESS;
+    }
 
-  return CallbackReturn::SUCCESS;
-}
+    return_type OdriveHardware::read(
+        const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
+    {
+        // TODO(anyone): read robot states
+        this->odrive->update_motor_state();
+        hw_joint_state_ = this->odrive->get_pos();
 
-hardware_interface::return_type OdriveHardware::read(
-  const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
-{
-  // TODO(anyone): read robot states
-  this->odrive->update_motor_state();
-  hw_joint_state_  = this->odrive->get_pos();
+        return return_type::OK;
+    }
 
-  return hardware_interface::return_type::OK;
-}
+    return_type OdriveHardware::write(
+        const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
+    {
 
-hardware_interface::return_type OdriveHardware::write(
-  const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
-{
-  
-  if (!std::isnan(hw_joint_command_))
-    this->odrive->set_input_torque( hw_joint_command_);
+        if (!std::isnan(hw_joint_command_))
+            this->odrive->set_input_torque(hw_joint_command_);
 
-  return hardware_interface::return_type::OK;
-}
+        return return_type::OK;
+    }
 
-}  // namespace odrive_hw_interface
+} // namespace odrive_hw_interface
 
 #include "pluginlib/class_list_macros.hpp"
 
 PLUGINLIB_EXPORT_CLASS(
-  odrive_hw_interface::OdriveHardware, hardware_interface::ActuatorInterface)
+    odrive_hw_interface::OdriveHardware, hardware_interface::ActuatorInterface)


### PR DESCRIPTION
Code simplification and formatting.
I don't like the "using", it's to avoid having to write hardware_interface all the time. it makes the code less cumbersome to read. If you have any suggestions for changing this without `using namespace hardware_interface`, please let me know.